### PR TITLE
:sparkles: Add developing environments using `nix develop`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,27 @@
         devShells.default = pkgs.mkShell {
           # Should there be packages here or use Nix purely for CI?
           LD_LIBRARY_PATH = lib.makeLibraryPath (__concatMap (d: d.runtimeDependencies) (__attrValues self'.checks));
+          # Basic Developing Components using `nix develop`
+          buildInputs = with pkgs; [
+          rust-bin.nightly.latest.default
+          rust-analyzer
+          rustfmt
+          pkg-config
+          cmake
+          autoPatchelfHook
+          fontconfig
+          stdenv.cc.cc.lib
+          wayland
+          libdrm
+          libGL
+          libffi
+          libinput
+          libseat
+          libwacom
+          libxkbcommon
+          mesa # For libgbm
+          systemd # For libudev
+          ];
         };
       };
     };


### PR DESCRIPTION
Added shell environments here this help any nix-shell users/contributor to easily load all required libs/dependencies and rust-bin with rust-analyzer and rustfmt.

There is some lua lib path issue on NixOS but we can bypass and run it by modify $XDG_DATA_DIRS with
```sh
export XDG_DATA_DIRS=$HOME/.local/share:$XDG_DATA_DIRS
```
and copy lua dir to `.local/share/strata/`

I'll try to add Makefile config to `flake.nix` and edit some environments variable there later. or maybe redirect lua lib path to main repo directory on debug mode.
