### PR TITLE
use proc macros to remove boilerplate when defining config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,6 +1560,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "scan_fmt"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,6 +1650,17 @@ name = "smallvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+
+[[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
 
 [[package]]
 name = "smithay"
@@ -1752,9 +1769,12 @@ dependencies = [
  "mlua",
  "once_cell",
  "parking_lot",
+ "smart-default",
  "smithay",
  "smithay-drm-extras",
+ "strata-core",
  "strata-derive",
+ "strum",
  "tokio",
  "tracing-appender",
  "tracing-subscriber",
@@ -1762,10 +1782,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "strata-derive"
+name = "strata-core"
 version = "0.1.0"
 dependencies = [
  "mlua",
+]
+
+[[package]]
+name = "strata-derive"
+version = "0.1.0"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.29",
@@ -1776,6 +1802,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6069ca09d878a33f883cc06aaa9718ede171841d3832450354410b718b097232"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.29",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ lazy_static = "1.4.0"
 parking_lot = "0.12.1"
 xdg = "2.5.2"
 strata-derive = { path = "strata-derive" }
+strata-core = { path = "strata-core" }
+smart-default = "0.7.1"
+strum = { version = "0.25.0", features = ["derive"] }
 
 [dependencies.smithay]
 default-features = false

--- a/lua/strata/rules.lua
+++ b/lua/strata/rules.lua
@@ -37,7 +37,7 @@ end
 function module.bind_to_workspace(inputs)
 	return map_rules(inputs, function(input)
 		return {
-			triggers = { event = "win_open_pre", class_name = input[2] },
+			triggers = { { event = "win_open_pre", class_name = input[2] } },
 			action = function(window) window:move_to_workspace(input[1]) end,
 		}
 	end)
@@ -49,7 +49,7 @@ end
 function module.set_floating(inputs)
 	return map_rules(inputs, function(input)
 		return {
-			triggers = { event = "win_open_pre", class_name = input[1] },
+			triggers = { { event = "win_open_pre", class_name = input[1] } },
 			action = function(window) window:set_floating() end,
 		}
 	end)

--- a/src/libs/backends/winit.rs
+++ b/src/libs/backends/winit.rs
@@ -108,7 +108,7 @@ pub fn init_winit() {
 		.unwrap();
 
 	// Autostart applications
-	for cmd in &CONFIG.read().options.autostart {
+	for cmd in &CONFIG.read().autostart {
 		Command::new("/bin/sh").arg("-c").args(cmd).spawn().ok();
 	}
 

--- a/src/libs/config/from_lua.rs
+++ b/src/libs/config/from_lua.rs
@@ -5,85 +5,12 @@ use mlua::{
 	Table,
 	Value,
 };
+use strata_core::UpdateFromLua;
 
 use super::{
-	Cmd,
-	Keybinding,
 	LuaFunction,
 	Rule,
 };
-
-#[derive(Debug, Default, strata_derive::FromLua)]
-pub(super) struct General {
-	pub workspaces: Option<u8>,
-	pub gaps_in: Option<i32>,
-	pub gaps_out: Option<i32>,
-	pub kb_repeat: Option<Vec<i32>>,
-}
-
-#[derive(Debug, Default, strata_derive::FromLua)]
-pub(super) struct WindowDecorations {
-	pub border: Option<Border>,
-	pub window: Option<Window>,
-	pub blur: Option<Blur>,
-	pub shadow: Option<Shadow>,
-}
-
-#[derive(Debug, Default, strata_derive::FromLua)]
-pub(super) struct Border {
-	pub enable: Option<bool>,
-	pub width: Option<u32>,
-	pub active: Option<String>,
-	pub inactive: Option<String>,
-	pub radius: Option<f64>,
-}
-
-#[derive(Debug, Default, strata_derive::FromLua)]
-pub(super) struct Window {
-	pub opacity: Option<f64>,
-}
-
-#[derive(Debug, Default, strata_derive::FromLua)]
-pub(super) struct Blur {
-	pub enable: Option<bool>,
-	pub size: Option<u32>,
-	pub passes: Option<u32>,
-	pub optimize: Option<bool>,
-}
-
-#[derive(Debug, Default, strata_derive::FromLua)]
-pub(super) struct Shadow {
-	pub enable: Option<bool>,
-	pub size: Option<u32>,
-	pub blur: Option<u32>,
-	pub color: Option<String>,
-}
-
-#[derive(Debug, Default, strata_derive::FromLua)]
-pub(super) struct Tiling {
-	pub layout: Option<String>,
-}
-
-#[derive(Debug, Default, strata_derive::FromLua)]
-pub(super) struct Animations {
-	pub enable: Option<bool>,
-}
-
-#[derive(Debug, Default)]
-pub(super) struct Rules {
-	pub list: Vec<Rule>,
-}
-
-#[derive(Debug, Default, strata_derive::FromLua)]
-pub(super) struct Config {
-	pub autostart: Vec<Cmd>,
-	pub general: General,
-	pub decorations: WindowDecorations,
-	pub tiling: Tiling,
-	pub animations: Animations,
-	pub bindings: Vec<Keybinding>,
-	pub rules: Rules,
-}
 
 impl<'lua> FromLua<'lua> for LuaFunction {
 	fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> mlua::Result<Self> {
@@ -91,14 +18,16 @@ impl<'lua> FromLua<'lua> for LuaFunction {
 	}
 }
 
-impl<'lua> FromLua<'lua> for Rules {
-	fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> mlua::Result<Self> {
-		let mut ret = Rules::default();
-
-		ret.add_sequence(Table::from_lua(value, lua)?)?;
-
-		Ok(ret)
+impl<'lua> UpdateFromLua<'lua> for LuaFunction {
+	fn update_from_lua(&mut self, value: Value<'lua>, lua: &'lua Lua) -> mlua::Result<()> {
+		self.key = lua.create_registry_value(Function::from_lua(value, lua)?)?;
+		Ok(())
 	}
+}
+
+#[derive(Debug, Default)]
+pub(super) struct Rules {
+	pub list: Vec<Rule>,
 }
 
 impl Rules {
@@ -117,94 +46,18 @@ impl Rules {
 	}
 }
 
-// TODO: Find an elegant way to remove or generate this boilerplate, and define the defaults elsewhere
+impl<'lua> FromLua<'lua> for Rules {
+	fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> mlua::Result<Self> {
+		let mut ret = Rules::default();
 
-impl Into<super::Config> for Config {
-	fn into(self) -> super::Config {
-		super::Config {
-			options: super::Options {
-				autostart: self.autostart,
-				general: self.general.into(),
-				decorations: self.decorations.into(),
-				tiling: self.tiling.into(),
-				animations: self.animations.into(),
-			},
-			bindings: self.bindings.into_iter().map(Into::into).collect(),
-			rules: self.rules.list,
-		}
+		ret.add_sequence(Table::from_lua(value, lua)?)?;
+
+		Ok(ret)
 	}
 }
 
-impl Into<super::General> for General {
-	fn into(self) -> super::General {
-		super::General {
-			workspaces: self.workspaces.unwrap_or(10),
-			gaps_in: self.gaps_in.unwrap_or(0),
-			gaps_out: self.gaps_out.unwrap_or(0),
-			kb_repeat: self.kb_repeat.unwrap_or(vec![]),
-		}
-	}
-}
-
-impl Into<super::WindowDecorations> for WindowDecorations {
-	fn into(self) -> super::WindowDecorations {
-		super::WindowDecorations {
-			border: self.border.unwrap_or_default().into(),
-			window: self.window.unwrap_or_default().into(),
-			blur: self.blur.unwrap_or_default().into(),
-			shadow: self.shadow.unwrap_or_default().into(),
-		}
-	}
-}
-
-impl Into<super::Border> for Border {
-	fn into(self) -> super::Border {
-		super::Border {
-			enable: self.enable.unwrap_or(true),
-			width: self.width.unwrap_or(1),
-			active: self.active.unwrap_or("#ffffff".to_string()),
-			inactive: self.inactive.unwrap_or("#ffffff".to_string()),
-			radius: self.radius.unwrap_or(0.0),
-		}
-	}
-}
-
-impl Into<super::Window> for Window {
-	fn into(self) -> super::Window {
-		super::Window { opacity: self.opacity.unwrap_or(1.0) }
-	}
-}
-
-impl Into<super::Blur> for Blur {
-	fn into(self) -> super::Blur {
-		super::Blur {
-			enable: self.enable.unwrap_or(true),
-			size: self.size.unwrap_or(10),
-			passes: self.passes.unwrap_or(1),
-			optimize: self.optimize.unwrap_or(true),
-		}
-	}
-}
-
-impl Into<super::Shadow> for Shadow {
-	fn into(self) -> super::Shadow {
-		super::Shadow {
-			enable: self.enable.unwrap_or(true),
-			size: self.size.unwrap_or(10),
-			blur: self.blur.unwrap_or(10),
-			color: self.color.unwrap_or("#000000".to_string()),
-		}
-	}
-}
-
-impl Into<super::Tiling> for Tiling {
-	fn into(self) -> super::Tiling {
-		super::Tiling { layout: self.layout.unwrap_or("bsp".to_string()) }
-	}
-}
-
-impl Into<super::Animations> for Animations {
-	fn into(self) -> super::Animations {
-		super::Animations { enable: self.enable.unwrap_or(true) }
+impl Into<Vec<Rule>> for Rules {
+	fn into(self) -> Vec<Rule> {
+		self.list
 	}
 }

--- a/src/libs/config/from_lua.rs
+++ b/src/libs/config/from_lua.rs
@@ -31,14 +31,13 @@ pub(super) struct Rules {
 }
 
 impl Rules {
-	pub fn add_sequence(&mut self, rules: Table) -> mlua::Result<()> {
+	pub fn add_sequence(&mut self, rules: Table, lua: &Lua) -> mlua::Result<()> {
 		for value in rules.sequence_values::<Table>() {
 			let value = value?;
 			if value.contains_key("triggers")? {
-				self.list
-					.push(Rule { triggers: value.get("triggers")?, action: value.get("action")? });
+				self.list.push(Rule::from_lua(Value::Table(value), lua)?);
 			} else {
-				self.add_sequence(value)?;
+				self.add_sequence(value, lua)?;
 			}
 		}
 
@@ -50,7 +49,7 @@ impl<'lua> FromLua<'lua> for Rules {
 	fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> mlua::Result<Self> {
 		let mut ret = Rules::default();
 
-		ret.add_sequence(Table::from_lua(value, lua)?)?;
+		ret.add_sequence(Table::from_lua(value, lua)?, lua)?;
 
 		Ok(ret)
 	}

--- a/src/libs/config/mod.rs
+++ b/src/libs/config/mod.rs
@@ -4,4 +4,3 @@ mod structs;
 
 pub use parse::parse_config;
 pub use structs::*;
-

--- a/src/libs/config/parse.rs
+++ b/src/libs/config/parse.rs
@@ -11,8 +11,7 @@ use mlua::{
 	Value,
 };
 use std::path::PathBuf;
-
-use super::from_lua::{self,};
+use strata_core::UpdateFromLua;
 
 struct StrataApi;
 
@@ -38,8 +37,7 @@ impl StrataApi {
 	}
 
 	pub fn set_config(lua: &Lua, config: Value) -> Result<()> {
-		let config: from_lua::Config = FromLua::from_lua(config, lua)?;
-		CONFIG.write().set(config.into());
+		CONFIG.write().set(FromLua::from_lua(config, lua)?);
 
 		Ok(())
 	}
@@ -49,9 +47,8 @@ impl StrataApi {
 		unimplemented!()
 	}
 
-	pub fn update_config(_lua: &Lua, _args: Value) -> Result<()> {
-		// TODO
-		unimplemented!()
+	pub fn update_config(lua: &Lua, args: Value) -> Result<()> {
+		CONFIG.write().update_from_lua(args, lua)
 	}
 }
 

--- a/src/libs/config/structs.rs
+++ b/src/libs/config/structs.rs
@@ -1,23 +1,25 @@
 use mlua::{
+	FromLua,
 	Function,
 	IntoLua,
 	RegistryKey,
 };
+use smart_default::SmartDefault;
+use strata_derive::Config;
+use strum::EnumString;
 
-#[derive(Debug, Default)]
+use super::from_lua;
+
+#[derive(Debug, Default, Config)]
 pub struct Config {
-	pub options: Options,
-	pub bindings: Vec<Keybinding>,
-	pub rules: Vec<Rule>,
-}
-
-#[derive(Debug, Default)]
-pub struct Options {
 	pub autostart: Vec<Cmd>,
 	pub general: General,
 	pub decorations: WindowDecorations,
 	pub tiling: Tiling,
 	pub animations: Animations,
+	pub bindings: Vec<Keybinding>,
+	#[config(from = from_lua::Rules)]
+	pub rules: Vec<Rule>,
 }
 
 #[derive(Debug)]
@@ -38,15 +40,18 @@ impl LuaFunction {
 
 pub type Cmd = Vec<String>;
 
-#[derive(Debug, Default)]
+#[derive(Debug, SmartDefault, Config)]
 pub struct General {
+	#[default(10)]
 	pub workspaces: u8,
+	#[default(5)]
 	pub gaps_in: i32,
+	#[default(10)]
 	pub gaps_out: i32,
 	pub kb_repeat: Vec<i32>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Config)]
 pub struct WindowDecorations {
 	pub border: Border,
 	pub window: Window,
@@ -54,72 +59,93 @@ pub struct WindowDecorations {
 	pub shadow: Shadow,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, SmartDefault, Config)]
 pub struct Border {
 	pub enable: bool,
+	#[default(2)]
 	pub width: u32,
+	#[default("#ffffff")]
 	pub active: String,
+	#[default("#888888")]
 	pub inactive: String,
+	#[default(5.0)]
 	pub radius: f64,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, SmartDefault, Config)]
 pub struct Window {
+	#[default(1.0)]
 	pub opacity: f64,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, SmartDefault, Config)]
 pub struct Blur {
 	pub enable: bool,
+	#[default(5)]
 	pub size: u32,
+	#[default(1)]
 	pub passes: u32,
+	#[default(true)]
 	pub optimize: bool,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, SmartDefault, Config)]
 pub struct Shadow {
 	pub enable: bool,
+	#[default(5)]
 	pub size: u32,
+	#[default(5)]
 	pub blur: u32,
+	#[default("#000000")]
 	pub color: String,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Config)]
 pub struct Tiling {
-	pub layout: String,
+	pub layout: Layout,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, EnumString, Config)]
+#[strum(serialize_all = "snake_case")]
+pub enum Layout {
+	#[default]
+	Dwindle,
+}
+
+#[derive(Debug, SmartDefault, Config)]
 pub struct Animations {
+	#[default(true)]
 	pub enable: bool,
 }
 
-#[derive(Debug, strata_derive::FromLua)]
+#[derive(Debug, Config)]
 pub struct Keybinding {
+	#[config(flat)]
 	pub keys: Vec<String>,
+	#[config(flat)]
 	pub action: LuaFunction,
 }
 
-#[derive(Debug, strata_derive::FromLua)]
+#[derive(Debug, Config)]
 pub struct Rule {
+	#[config(flat)]
 	pub triggers: Vec<Trigger>,
+	#[config(flat)]
 	pub action: LuaFunction,
 }
 
-#[derive(Debug, strata_derive::FromLua)]
+#[derive(Debug, Config)]
 pub struct Trigger {
+	#[config(flat)]
 	pub event: String,
+	#[config(flat)]
 	pub class_name: Option<String>,
+	#[config(flat)]
 	pub workspace: Option<i32>,
 }
 
 impl Config {
 	pub fn set(&mut self, config: Config) {
 		*self = config;
-	}
-
-	pub fn update(&mut self, config: Config) {
-		// TODO
-		unimplemented!()
 	}
 }

--- a/src/libs/decorations/borders.rs
+++ b/src/libs/decorations/borders.rs
@@ -80,7 +80,7 @@ impl BorderShader {
 		window: &Window,
 		loc: Point<i32, Logical>,
 	) -> PixelShaderElement {
-		let thickness: f32 = CONFIG.read().options.decorations.border.width as f32;
+		let thickness: f32 = CONFIG.read().decorations.border.width as f32;
 		let thickness_loc = (thickness as i32, thickness as i32);
 		let thickness_size = ((thickness * 2.0) as i32, (thickness * 2.0) as i32);
 		let geo = Rectangle::from_loc_and_size(
@@ -102,7 +102,7 @@ impl BorderShader {
 		} else {
 			let angle = 45 as f32 * std::f32::consts::PI;
 			let gradient_direction = [angle.cos(), angle.sin()];
-			let elem = if CONFIG.read().options.decorations.border.radius > 0.0 {
+			let elem = if CONFIG.read().decorations.border.radius > 0.0 {
 				PixelShaderElement::new(
 					Self::get(renderer).rounded.clone(),
 					geo,
@@ -118,8 +118,7 @@ impl BorderShader {
 						Uniform::new("halfThickness", thickness * 0.5),
 						Uniform::new(
 							"radius",
-							CONFIG.read().options.decorations.border.radius as f32
-								+ thickness + 2.0,
+							CONFIG.read().decorations.border.radius as f32 + thickness + 2.0,
 						),
 						Uniform::new("gradientDirection", gradient_direction),
 					],

--- a/src/libs/state.rs
+++ b/src/libs/state.rs
@@ -81,7 +81,7 @@ impl<BackendData: Backend> StrataState<BackendData> {
 		display: &mut Display<StrataState<BackendData>>,
 		backend_data: BackendData,
 	) -> Self {
-		let options = &CONFIG.read().options;
+		let config = &CONFIG.read();
 
 		let start_time = Instant::now();
 		let dh = display.handle();
@@ -96,15 +96,15 @@ impl<BackendData: Backend> StrataState<BackendData> {
 		let seat_name = backend_data.seat_name();
 		let mut seat = seat_state.new_wl_seat(&dh, seat_name.clone());
 		let layer_shell_state = WlrLayerShellState::new::<Self>(&dh);
-		let key_delay: i32 = options.general.kb_repeat[0];
-		let key_repeat: i32 = options.general.kb_repeat[1];
-		if !options.general.kb_repeat.is_empty() {
+		let key_delay: i32 = config.general.kb_repeat[0];
+		let key_repeat: i32 = config.general.kb_repeat[1];
+		if !config.general.kb_repeat.is_empty() {
 			seat.add_keyboard(XkbConfig::default(), key_delay, key_repeat)
 				.expect("Couldn't parse XKB config");
 		} else {
 			seat.add_keyboard(XkbConfig::default(), 500, 250).expect("Couldn't parse XKB config");
 		}
-		let config_workspace: u8 = options.general.workspaces.clone();
+		let config_workspace: u8 = config.general.workspaces.clone();
 		let workspaces = Workspaces::new(config_workspace);
 		seat.add_pointer();
 		let socket_name = Self::init_wayland_listener(&mut loop_handle, display);

--- a/src/libs/tiling.rs
+++ b/src/libs/tiling.rs
@@ -25,8 +25,8 @@ use smithay::{
 
 pub fn refresh_geometry(workspace: &mut Workspace) {
 	let gaps = {
-		let options = &CONFIG.read().options;
-		(options.general.gaps_out, options.general.gaps_in)
+		let config = &CONFIG.read();
+		(config.general.gaps_out, config.general.gaps_in)
 	};
 	let output = layer_map_for_output(workspace.outputs().next().unwrap()).non_exclusive_zone();
 	let output_full = workspace.outputs().next().unwrap().current_mode().unwrap().size;

--- a/src/libs/workspaces.rs
+++ b/src/libs/workspaces.rs
@@ -105,7 +105,7 @@ impl Workspace {
 		let mut render_elements: Vec<C> = Vec::new();
 		for element in &self.windows {
 			let window = &element.borrow().window;
-			if CONFIG.read().options.decorations.border.width > 0 {
+			if CONFIG.read().decorations.border.width > 0 {
 				render_elements.push(C::from(BorderShader::element(
 					renderer.glow_renderer_mut(),
 					window,

--- a/strata-core/Cargo.toml
+++ b/strata-core/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "strata-core"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+
+[dependencies]
+mlua = { version = "0.9.1", features = ["luajit", "vendored"] }

--- a/strata-core/src/lib.rs
+++ b/strata-core/src/lib.rs
@@ -1,0 +1,39 @@
+use mlua::{
+	FromLua,
+	Lua,
+	Result,
+	Value,
+};
+
+pub trait UpdateFromLua<'lua>: FromLua<'lua> {
+	fn update_from_lua(&mut self, value: Value<'lua>, lua: &'lua Lua) -> Result<()>;
+}
+
+macro_rules! impl_update_from_lua {
+	($($ty:ty),*) => {
+		$(
+			impl<'lua> UpdateFromLua<'lua> for $ty {
+				fn update_from_lua(&mut self, value: Value<'lua>, _: &'lua Lua) -> Result<()> {
+					*self = Self::from_lua(value, &Lua::new())?;
+					Ok(())
+				}
+			}
+		)*
+	};
+}
+
+impl_update_from_lua!(bool, i8, i16, i32, i64, u8, u16, u32, u64, f32, f64, String);
+
+impl<'lua, T: FromLua<'lua>> UpdateFromLua<'lua> for Vec<T> {
+	fn update_from_lua(&mut self, value: Value<'lua>, lua: &'lua Lua) -> Result<()> {
+		*self = FromLua::from_lua(value, lua)?;
+		Ok(())
+	}
+}
+
+impl<'lua, T: FromLua<'lua>> UpdateFromLua<'lua> for Option<T> {
+	fn update_from_lua(&mut self, value: Value<'lua>, lua: &'lua Lua) -> Result<()> {
+		*self = FromLua::from_lua(value, lua)?;
+		Ok(())
+	}
+}

--- a/strata-derive/Cargo.toml
+++ b/strata-derive/Cargo.toml
@@ -6,10 +6,7 @@ edition = "2021"
 [lib]
 proc-macro = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-mlua = { version = "0.9.1", features = ["luajit", "vendored"] }
 proc-macro2 = "1.0.66"
 quote = "1.0.33"
 syn = "2.0.29"

--- a/strata-derive/src/lib.rs
+++ b/strata-derive/src/lib.rs
@@ -4,32 +4,146 @@ use quote::{
 	quote_spanned,
 	spanned::Spanned,
 };
+use syn::Attribute;
 
-#[proc_macro_derive(FromLua)]
-pub fn from_lua_derive(input: TokenStream) -> TokenStream {
+struct ConfigAttrs {
+	is_flat: bool,
+	from_type: Option<syn::Type>,
+}
+
+impl<'a, T> From<T> for ConfigAttrs
+where
+	T: IntoIterator<Item = &'a Attribute>,
+{
+	fn from(iter: T) -> Self {
+		let mut ret = Self { is_flat: false, from_type: None };
+
+		for attr in iter {
+			attr.parse_nested_meta(|meta| {
+				if meta.path.is_ident("from") {
+					ret.from_type = Some(meta.value()?.parse()?);
+				} else if meta.path.is_ident("flat") {
+					ret.is_flat = true;
+				} else {
+					panic!("unknown attribute");
+				}
+				Ok(())
+			})
+			.expect("failed to parse attribute");
+		}
+
+		ret
+	}
+}
+
+/// Procedural macro to derive a wrapper with optional fields around a struct.
+#[proc_macro_derive(Config, attributes(config))]
+pub fn config_derive(input: TokenStream) -> TokenStream {
 	let input = syn::parse_macro_input!(input as syn::DeriveInput);
 
 	match input.data {
 		syn::Data::Struct(ref struct_data) => {
-			let struct_name = input.ident.clone();
-			let struct_fields = struct_data.fields.iter().filter_map(|field| field.ident.as_ref());
+			let struct_name = input.ident;
+			let fields = struct_data.fields.iter().map(|field| {
+				let attrs = ConfigAttrs::from(
+					field.attrs.iter().filter(|attr| attr.path().is_ident("config")),
+				);
+				(field.ident.as_ref().unwrap(), &field.ty, attrs)
+			});
+
+			let from_lua_fields = fields.clone().map(|(field_name, field_type, attrs)| {
+				let field_type = attrs.from_type.as_ref().unwrap_or(field_type);
+				let field_value = if attrs.is_flat {
+					quote! {
+						table.get::<_, #field_type>(stringify!(#field_name))?.into()
+					}
+				} else {
+					quote! {
+						table
+							.get::<_, Option<#field_type>>(stringify!(#field_name))?
+							.map(Into::into)
+							.unwrap_or_default()
+					}
+				};
+
+				quote! {
+					#field_name: #field_value
+				}
+			});
+
+			let update_from_lua_fields = fields.map(|(field_name, _field_type, attrs)| {
+				match (attrs.is_flat, attrs.from_type) {
+					(true, None) => {
+						quote! {
+							self.#field_name.update_from_lua(table.get(stringify!(#field_name))?, lua)?;
+						}
+					}
+					(true, Some(from_type)) => {
+						quote! {
+							self.#field_name = table.get::<_, #from_type>(stringify!(#field_name))?.into();
+						}
+					}
+					(false, None) => {
+						quote! {
+							if let Some(value) = table.get::<_, Option<mlua::Value>>(stringify!(#field_name))? {
+								self.#field_name.update_from_lua(value, lua)?;
+							}
+						}
+					}
+					(false, Some(from_type)) => {
+						quote! {
+							if let Some(value) = table.get::<_, Option<#from_type>>(stringify!(#field_name))? {
+								self.#field_name = value.into();
+							}
+						}
+					}
+				}
+			});
 
 			quote! {
 				impl<'lua> mlua::FromLua<'lua> for #struct_name {
 					fn from_lua(value: mlua::Value<'lua>, lua: &'lua mlua::Lua) -> mlua::Result<Self> {
 						let table = mlua::Table::from_lua(value, lua)?;
 						Ok(Self {
-							#(
-								#struct_fields: table.get(stringify!(#struct_fields))?
-							),*
+							#(#from_lua_fields),*
 						})
+					}
+				}
+
+				impl<'lua> strata_core::UpdateFromLua<'lua> for #struct_name {
+					fn update_from_lua(&mut self, value: mlua::Value<'lua>, lua: &'lua mlua::Lua) -> mlua::Result<()> {
+						let table = mlua::Table::from_lua(value, lua)?;
+						#(#update_from_lua_fields)*
+						Ok(())
+					}
+				}
+			}
+		}
+		syn::Data::Enum(_) => {
+			let enum_name = input.ident;
+			quote! {
+				impl<'lua> mlua::FromLua<'lua> for #enum_name {
+					fn from_lua(value: mlua::Value<'lua>, lua: &'lua mlua::Lua) -> mlua::Result<Self> {
+						let str = String::from_lua(value, lua)?;
+						 std::str::FromStr::from_str(&str).map_err(|_| mlua::Error::FromLuaConversionError {
+							from: "string",
+							to: stringify!(#enum_name),
+							message: Some("invalid variant".to_owned()),
+						})
+					}
+				}
+
+				impl<'lua> strata_core::UpdateFromLua<'lua> for #enum_name {
+					fn update_from_lua(&mut self, value: mlua::Value<'lua>, lua: &'lua mlua::Lua) -> mlua::Result<()> {
+						*self = Self::from_lua(value, lua)?;
+						Ok(())
 					}
 				}
 			}
 		}
 		_ => {
 			quote_spanned! {
-				input.__span() => compile_error!("FromLua can only be derived for structs");
+				input.ident.__span() => compile_error!("Config can only be derived for structs and enums");
 			}
 		}
 	}

--- a/strata-derive/tests/test_derive.rs
+++ b/strata-derive/tests/test_derive.rs
@@ -3,22 +3,22 @@ use mlua::{
 	Lua,
 	Value,
 };
-use strata_derive::FromLua;
+use strata_derive::Config;
 
-#[derive(Debug, PartialEq, FromLua)]
-struct MyStruct {
+#[derive(Debug, PartialEq, Default, Config)]
+struct Foo {
 	a: i32,
+	#[config(flat)]
 	b: String,
 }
 
 #[test]
-fn test_from_lua() {
+fn test_config() {
 	let lua = Lua::new();
 	let table = lua.create_table().unwrap();
-	table.set("a", 1).unwrap();
 	table.set("b", "hello").unwrap();
 
-	let my_struct: MyStruct = FromLua::from_lua(Value::Table(table), &lua).unwrap();
+	let foo: Foo = FromLua::from_lua(Value::Table(table), &lua).unwrap();
 
-	assert_eq!(my_struct, MyStruct { a: 1, b: "hello".to_string() });
+	assert_eq!(foo, Foo { a: 0, b: "hello".to_string() });
 }


### PR DESCRIPTION
This new `Config` proc macro is a bit complicated but it lets us define everything we want about configuration options, including default values, in a single file (currently `src/libs/config/structs.rs`).