### PR TITLE
moving the parse_config() function to winit.rs

### DIFF
--- a/src/libs/backends.rs
+++ b/src/libs/backends.rs
@@ -5,7 +5,7 @@ use std::error::Error;
 pub async fn init_with_backend(backend_name: String) -> Result<(), Box<dyn Error>> {
 	match backend_name.as_str() {
 		"winit" => {
-			winit::init_winit();
+			winit::init_winit().await?;
 			Ok(())
 		}
 		"udev" => {

--- a/src/libs/backends.rs
+++ b/src/libs/backends.rs
@@ -1,16 +1,20 @@
 pub mod winit;
 use log::error;
+use std::error::Error;
 
-pub fn init_with_backend(backend_name: &str) {
-	match backend_name {
+pub async fn init_with_backend(backend_name: String) -> Result<(), Box<dyn Error>> {
+	match backend_name.as_str() {
 		"winit" => {
 			winit::init_winit();
+			Ok(())
 		}
 		"udev" => {
 			error!("Udev is not implemented yet!");
+			Ok(())
 		}
 		unknown => {
-			error!("Unknown backend provided: {}", unknown)
+			error!("Unknown backend provided: {}", unknown);
+			Ok(())
 		}
 	}
 }

--- a/src/libs/backends/winit.rs
+++ b/src/libs/backends/winit.rs
@@ -109,7 +109,7 @@ pub async fn init_winit() -> Result<(), Box<dyn Error>> {
 		.unwrap();
 
 	if let (Some(config_path), Some(data_path)) = (config_dir, lib_dir) {
-		parse_config(config_path, data_path);
+		parse_config(config_path, data_path).await?;
 	}
 
 	// Autostart applications

--- a/src/libs/backends/winit.rs
+++ b/src/libs/backends/winit.rs
@@ -109,7 +109,7 @@ pub async fn init_winit() -> Result<(), Box<dyn Error>> {
 		.unwrap();
 
 	if let (Some(config_path), Some(data_path)) = (config_dir, lib_dir) {
-		parse_config(config_path, data_path).await?;
+		tokio::spawn(async { parse_config(config_path, data_path) }).await?.await?;
 	}
 
 	// Autostart applications

--- a/src/libs/backends/winit.rs
+++ b/src/libs/backends/winit.rs
@@ -55,6 +55,10 @@ use smithay::{
 use std::{
 	error::Error,
 	process::Command,
+	sync::{
+		Arc,
+		Mutex,
+	},
 	time::Duration,
 };
 
@@ -108,6 +112,9 @@ pub async fn init_winit() -> Result<(), Box<dyn Error>> {
 		})
 		.unwrap();
 
+	let state_arc: Arc<Mutex<&mut StrataState>> = Arc::new(Mutex::new(state));
+
+	// Parse config.
 	if let (Some(config_path), Some(data_path)) = (config_dir, lib_dir) {
 		tokio::spawn(async { parse_config(config_path, data_path) }).await?.await?;
 	}

--- a/src/libs/backends/winit.rs
+++ b/src/libs/backends/winit.rs
@@ -109,7 +109,7 @@ pub async fn init_winit() -> Result<(), Box<dyn Error>> {
 		.unwrap();
 
 	if let (Some(config_path), Some(data_path)) = (config_dir, lib_dir) {
-		tokio::spawn(async { parse_config(config_path, data_path) }).await?;
+		parse_config(config_path, data_path);
 	}
 
 	// Autostart applications

--- a/src/libs/config/parse.rs
+++ b/src/libs/config/parse.rs
@@ -52,7 +52,7 @@ impl StrataApi {
 	}
 }
 
-pub fn parse_config(config_dir: PathBuf, lib_dir: PathBuf) -> Result<()> {
+pub async fn parse_config(config_dir: PathBuf, lib_dir: PathBuf) -> Result<()> {
 	let lua = LUA.lock();
 	let api_submod = get_or_create_module(&lua, "strata.api").unwrap(); // TODO: remove unwrap
 

--- a/src/libs/state.rs
+++ b/src/libs/state.rs
@@ -201,39 +201,6 @@ impl StrataState {
 		};
 		under
 	}
-
-	pub fn close_window(&mut self) {
-		if let Some(d) = self.workspaces.current().window_under(self.pointer_location) {
-			d.0.toplevel().send_close()
-		}
-	}
-
-	pub fn switch_to_workspace(&mut self, id: u8) {
-		self.workspaces.activate(id);
-		self.set_input_focus_auto();
-	}
-
-	pub fn move_window_to_workspace(&mut self, id: u8) {
-		let window =
-			self.workspaces.current().window_under(self.pointer_location).map(|d| d.0.clone());
-
-		if let Some(window) = window {
-			self.workspaces.move_window_to_workspace(&window, id);
-		}
-	}
-
-	pub fn follow_window_move(&mut self, id: u8) {
-		self.move_window_to_workspace(id);
-		self.switch_to_workspace(id);
-	}
-
-	pub fn quit(&mut self) {
-		self.loop_signal.stop();
-	}
-
-	pub fn spawn(&mut self, command: &str) {
-		Command::new("/bin/sh").arg("-c").arg(command).spawn().expect("Failed to spawn command");
-	}
 }
 
 #[derive(Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,5 @@
 mod libs;
-use crate::libs::config::{
-	parse_config,
-	Config,
-};
+use crate::libs::config::Config;
 use chrono::Local;
 use clap::Parser;
 use lazy_static::lazy_static;
@@ -52,7 +49,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 	}
 
 	let args = Args::parse();
-	tokio::spawn(async move { init_with_backend(args.backend) }).await?.await?;
+	init_with_backend(args.backend).await?;
 
 	info!("Initializing Strata WM");
 	info!("Parsing config...");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,8 @@
 mod libs;
+use crate::libs::config::{
+	parse_config,
+	Config,
+};
 use chrono::Local;
 use clap::Parser;
 use lazy_static::lazy_static;
@@ -22,11 +26,6 @@ use std::{
 	io::stdout,
 };
 use tracing_subscriber::fmt::writer::MakeWriterExt;
-
-use crate::libs::config::{
-	parse_config,
-	Config,
-};
 
 lazy_static! {
 	static ref LUA: ReentrantMutex<mlua::Lua> = ReentrantMutex::new(mlua::Lua::new());
@@ -60,8 +59,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 	}
 
 	let args = Args::parse();
-
-	init_with_backend(&args.backend);
+	tokio::spawn(async move { init_with_backend(args.backend) }).await?.await?;
 
 	info!("Initializing Strata WM");
 	info!("Parsing config...");

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,14 +35,7 @@ lazy_static! {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
 	let xdg = xdg::BaseDirectories::with_prefix("strata")?;
-
-	let config_dir = xdg.find_config_file("");
-	let lib_dir = xdg.find_data_file("lua");
 	let log_dir = xdg.get_state_home();
-
-	if let (Some(config_path), Some(data_path)) = (config_dir, lib_dir) {
-		tokio::spawn(async { parse_config(config_path, data_path) }).await??;
-	}
 
 	let file_appender = tracing_appender::rolling::never(
 		&log_dir,


### PR DESCRIPTION
I'm trying to move the `parse_config()` function which is currently being called from `main.rs` to `backends/winit.rs` so that a state variable, i.e, a variable of type `StrataState` can be passed as an argument to be used in the `parse_config` function.