### PR TITLE
fix: kb_repeat vec out of bounds

### DIFF
--- a/src/libs/state.rs
+++ b/src/libs/state.rs
@@ -103,9 +103,9 @@ impl StrataState {
 		let primary_selection_state = PrimarySelectionState::new::<Self>(&dh);
 		let mut seat = seat_state.new_wl_seat(&dh, seat_name.clone());
 		let layer_shell_state = WlrLayerShellState::new::<Self>(&dh);
-		let key_delay: i32 = config.general.kb_repeat[0];
-		let key_repeat: i32 = config.general.kb_repeat[1];
 		if !config.general.kb_repeat.is_empty() {
+			let key_delay: i32 = config.general.kb_repeat[0];
+			let key_repeat: i32 = config.general.kb_repeat[1];
 			seat.add_keyboard(XkbConfig::default(), key_delay, key_repeat)
 				.expect("Couldn't parse XKB config");
 		} else {


### PR DESCRIPTION
Check if kb_repeat vec is empty before indexing.